### PR TITLE
Add command to auto-assign participants to their computers

### DIFF
--- a/oi_seattracker/management/commands/assign_participants.py
+++ b/oi_seattracker/management/commands/assign_participants.py
@@ -1,0 +1,26 @@
+from django.core.management.base import BaseCommand
+from oi_seattracker.models import Participant, Computer
+import json
+
+class Command(BaseCommand):
+    help = 'Assigns participants to their computers based on a json file (so-called "autoassign")'
+    
+    def add_arguments(self, parser):
+        parser.add_argument('source_file', type=open)
+
+    def handle(self, *args, **options):
+        data = json.load(options['source_file'])
+        mapping = {}
+        for line in data:
+            participant_id = line[0]
+            identifier = line[1]
+            mapping[participant_id] = identifier
+
+        participants = Participant.objects.all()
+        for participant in participants:
+            try:
+                computer = Computer.objects.get(ip_address=mapping[participant.pk])
+            except:
+                computer = Computer.objects.get(nice_name=mapping[participant.pk])
+            participant.computer = computer
+            participant.save()


### PR DESCRIPTION
Automatically assigns participants to computers based on a JSON file. It reads participant-computer mappings from the provided file and updates the database by linking each participant to the corresponding computer based on either IP address or a predefined name.

The JSON file should be a list of pairs, where each entry is formatted as `[participant_id, computer_identifier]`. The `computer_identifier` can be either an IP address or a predefined name used to identify the computer in the `database.